### PR TITLE
Add zoom and fullscreen controls to redistricting map

### DIFF
--- a/redistricting/index.html
+++ b/redistricting/index.html
@@ -23,11 +23,11 @@
     <main id="top">
       <section class="hero">
         <div class="hero-copy">
-          <p class="label">Interactive investigation</p>
-          <h1>The public record against Florida's 24-4 map.</h1>
+          <p class="label">Interactive investigation v2</p>
+          <h1>The public record is the case against Florida's 24-4 map.</h1>
           <p class="dek">
-            The public record
-            shows how the map was built with partisan data to put the Fair Districts Amendments
+            The deeper story is not just that the map helps Republicans. It is how openly the record
+            says the map was built: partisan data in, race-neutral legal theory out, Fair Districts put
             on trial.
           </p>
           <div class="kpis" id="kpis"></div>
@@ -52,7 +52,17 @@
           </div>
           <div class="desk-body">
             <figure class="map-panel">
-              <svg id="districtMap" role="img" aria-labelledby="mapTitle mapDesc"></svg>
+              <div class="map-viewport">
+                <svg id="districtMap" role="img" aria-labelledby="mapTitle mapDesc"></svg>
+                <div class="map-tools" role="group" aria-label="Map zoom controls">
+                  <button data-map-zoom="in" type="button" aria-label="Zoom in" title="Zoom in">+</button>
+                  <button data-map-zoom="out" type="button" aria-label="Zoom out" title="Zoom out">-</button>
+                  <button data-map-zoom="reset" type="button" aria-label="Reset map zoom" title="Reset map zoom">1:1</button>
+                  <button data-map-zoom="district" type="button" aria-label="Zoom to selected district" title="Zoom to selected district">CD</button>
+                  <button data-map-fullscreen type="button" aria-label="Toggle fullscreen map" title="Toggle fullscreen map">Full</button>
+                </div>
+                <div id="mapLegend" class="map-legend" aria-hidden="true"></div>
+              </div>
               <figcaption>
                 <strong id="mapTitle">2026 congressional plan</strong>
                 <span id="mapDesc">Districts are colored by 2024 presidential margin.</span>

--- a/redistricting/redistricting-story_app_v2.css
+++ b/redistricting/redistricting-story_app_v2.css
@@ -241,14 +241,101 @@ h3 {
   border-right: 1px solid var(--ink);
 }
 
-#districtMap {
-  width: 100%;
-  height: min(68vh, 650px);
-  min-height: 530px;
+.map-viewport {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
   background:
     linear-gradient(rgba(16,21,22,.045) 1px, transparent 1px),
     linear-gradient(90deg, rgba(16,21,22,.045) 1px, transparent 1px);
   background-size: 32px 32px;
+}
+
+#districtMap {
+  display: block;
+  width: 100%;
+  height: min(68vh, 650px);
+  min-height: 530px;
+  cursor: grab;
+  touch-action: none;
+}
+
+#districtMap.is-panning {
+  cursor: grabbing;
+}
+
+.map-content {
+  transform-box: fill-box;
+  transform-origin: 0 0;
+}
+
+.map-tools {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 4;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-width: calc(100% - 20px);
+}
+
+.map-tools button {
+  min-width: 38px;
+  min-height: 34px;
+  padding: 6px 9px;
+  border: 1px solid var(--ink);
+  background: rgba(255, 250, 241, .96);
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 950;
+  box-shadow: 3px 3px 0 rgba(16, 21, 22, .14);
+}
+
+.map-tools button:hover,
+.map-tools button:focus-visible {
+  background: var(--ink);
+  color: #fffaf1;
+}
+
+.map-legend {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 3;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  max-width: calc(100% - 20px);
+  color: #202927;
+  font-size: 11px;
+  font-weight: 900;
+  pointer-events: none;
+}
+
+.map-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 4px 7px;
+  border: 1px solid rgba(16,21,22,.36);
+  background: rgba(255,250,241,.94);
+}
+
+.legend-line {
+  width: 28px;
+  height: 0;
+  border-top: 2px dashed var(--blue-deep);
+}
+
+.legend-fill {
+  width: 20px;
+  height: 12px;
+  border: 1px solid rgba(16,21,22,.45);
+  background: var(--red);
 }
 
 .district-path {
@@ -268,10 +355,11 @@ h3 {
 
 .old-outline {
   fill: none;
-  stroke: rgba(16,21,22,.58);
+  stroke: var(--blue-deep);
   stroke-dasharray: 3 3;
-  stroke-width: 1;
+  stroke-width: 1.45;
   vector-effect: non-scaling-stroke;
+  pointer-events: none;
 }
 
 .district-label {
@@ -297,6 +385,30 @@ figcaption {
 }
 
 figcaption strong { color: var(--ink); }
+
+.map-panel:fullscreen {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+  padding: 18px;
+  border: 0;
+  background: var(--paper-2);
+}
+
+.map-panel:fullscreen .map-viewport {
+  flex: 1;
+  min-height: 0;
+}
+
+.map-panel:fullscreen #districtMap {
+  height: 100%;
+  min-height: 0;
+}
+
+.map-panel:fullscreen figcaption {
+  flex: 0 0 auto;
+}
 
 .inspector {
   display: flex;

--- a/redistricting/redistricting-story_app_v2.js
+++ b/redistricting/redistricting-story_app_v2.js
@@ -15,8 +15,14 @@
     receiptDistrict: null,
     activeReceipt: null,
     activeSearchIndex: 0,
+    zoom: 1,
+    panX: 0,
+    panY: 0,
+    suppressDistrictClick: false,
   };
   let currentSearchResults = [];
+  let mapContent = null;
+  let dragState = null;
 
   const view = {
     width: 770,
@@ -192,14 +198,9 @@
     svg.setAttribute("viewBox", `0 0 ${view.width} ${view.height}`);
     svg.innerHTML = "";
 
-    if (state.mapMode === "overlay") {
-      data.maps.old.features.forEach((feature) => {
-        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-        path.setAttribute("d", geometryPath(feature.geometry));
-        path.setAttribute("class", "old-outline");
-        svg.appendChild(path);
-      });
-    }
+    mapContent = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    mapContent.setAttribute("class", "map-content");
+    svg.appendChild(mapContent);
 
     getPlanFeatures().forEach((feature) => {
       const id = Number(feature.properties.id || feature.properties.NAME);
@@ -212,8 +213,14 @@
       path.setAttribute("tabindex", "0");
       path.setAttribute("role", "button");
       path.setAttribute("aria-label", `District ${id}`);
-      path.style.opacity = state.mapMode === "overlay" ? "0.84" : "1";
-      path.addEventListener("click", () => selectDistrict(id));
+      path.style.opacity = state.mapMode === "overlay" ? "0.78" : "1";
+      path.addEventListener("click", (event) => {
+        if (state.suppressDistrictClick) {
+          event.preventDefault();
+          return;
+        }
+        selectDistrict(id);
+      });
       path.addEventListener("keydown", (event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
@@ -222,8 +229,17 @@
       });
       path.addEventListener("mousemove", (event) => showTooltip(event, metric));
       path.addEventListener("mouseleave", hideTooltip);
-      svg.appendChild(path);
+      mapContent.appendChild(path);
     });
+
+    if (state.mapMode === "overlay") {
+      data.maps.old.features.forEach((feature) => {
+        const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        path.setAttribute("d", geometryPath(feature.geometry));
+        path.setAttribute("class", "old-outline");
+        mapContent.appendChild(path);
+      });
+    }
 
     getPlanLabels().forEach((feature) => {
       const id = Number(feature.properties.id || feature.properties.NAME);
@@ -235,10 +251,12 @@
       text.setAttribute("y", y.toFixed(2));
       text.setAttribute("class", "district-label");
       text.textContent = id;
-      svg.appendChild(text);
+      mapContent.appendChild(text);
     });
 
+    applyMapTransform();
     updateMapCaption();
+    renderMapLegend();
   }
 
   function updateMapCaption() {
@@ -253,6 +271,128 @@
           : "Districts are colored by 2024 presidential margin.";
     title.textContent = plan;
     desc.textContent = layer;
+  }
+
+  function renderMapLegend() {
+    const legend = document.getElementById("mapLegend");
+    if (!legend) return;
+    if (state.mapMode !== "overlay") {
+      legend.innerHTML = "";
+      return;
+    }
+    legend.innerHTML = `
+      <span><i class="legend-fill"></i>2026 fill</span>
+      <span><i class="legend-line"></i>2022 outline</span>
+    `;
+  }
+
+  function applyMapTransform() {
+    if (!mapContent) return;
+    mapContent.setAttribute(
+      "transform",
+      `translate(${state.panX.toFixed(2)} ${state.panY.toFixed(2)}) scale(${state.zoom.toFixed(4)})`,
+    );
+  }
+
+  function svgPointFromEvent(event) {
+    const rect = svg.getBoundingClientRect();
+    return [
+      ((event.clientX - rect.left) / rect.width) * view.width,
+      ((event.clientY - rect.top) / rect.height) * view.height,
+    ];
+  }
+
+  function setMapZoom(nextZoom, origin = [view.width / 2, view.height / 2]) {
+    const oldZoom = state.zoom;
+    const zoom = clamp(nextZoom, 1, 8);
+    if (Math.abs(zoom - oldZoom) < 0.001) return;
+    state.panX = origin[0] - (origin[0] - state.panX) * (zoom / oldZoom);
+    state.panY = origin[1] - (origin[1] - state.panY) * (zoom / oldZoom);
+    state.zoom = zoom;
+    applyMapTransform();
+  }
+
+  function zoomMapBy(factor, origin) {
+    setMapZoom(state.zoom * factor, origin);
+  }
+
+  function resetMapView() {
+    state.zoom = 1;
+    state.panX = 0;
+    state.panY = 0;
+    applyMapTransform();
+  }
+
+  function currentFeatureForDistrict(id) {
+    return getPlanFeatures().find((feature) => Number(feature.properties.id || feature.properties.NAME) === Number(id));
+  }
+
+  function projectedBounds(feature) {
+    const box = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+    walkCoordinates(feature.geometry.coordinates, (coord) => {
+      const [x, y] = project(coord);
+      box.minX = Math.min(box.minX, x);
+      box.maxX = Math.max(box.maxX, x);
+      box.minY = Math.min(box.minY, y);
+      box.maxY = Math.max(box.maxY, y);
+    });
+    return box;
+  }
+
+  function focusSelectedDistrict() {
+    const feature = currentFeatureForDistrict(state.district);
+    if (!feature) return;
+    const box = projectedBounds(feature);
+    const width = Math.max(1, box.maxX - box.minX);
+    const height = Math.max(1, box.maxY - box.minY);
+    const padding = 120;
+    const zoom = clamp(Math.min((view.width - padding) / width, (view.height - padding) / height), 1.8, 8);
+    state.zoom = zoom;
+    state.panX = view.width / 2 - ((box.minX + box.maxX) / 2) * zoom;
+    state.panY = view.height / 2 - ((box.minY + box.maxY) / 2) * zoom;
+    applyMapTransform();
+  }
+
+  function startMapPan(event) {
+    if (event.button !== 0) return;
+    dragState = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      y: event.clientY,
+      panX: state.panX,
+      panY: state.panY,
+      moved: false,
+    };
+    svg.setPointerCapture(event.pointerId);
+    svg.classList.add("is-panning");
+  }
+
+  function continueMapPan(event) {
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    const rect = svg.getBoundingClientRect();
+    const dx = ((event.clientX - dragState.x) / rect.width) * view.width;
+    const dy = ((event.clientY - dragState.y) / rect.height) * view.height;
+    if (Math.abs(dx) + Math.abs(dy) > 2) dragState.moved = true;
+    state.panX = dragState.panX + dx;
+    state.panY = dragState.panY + dy;
+    applyMapTransform();
+  }
+
+  function endMapPan(event) {
+    if (!dragState || dragState.pointerId !== event.pointerId) return;
+    if (dragState.moved) {
+      state.suppressDistrictClick = true;
+      window.setTimeout(() => {
+        state.suppressDistrictClick = false;
+      }, 0);
+    }
+    try {
+      svg.releasePointerCapture(event.pointerId);
+    } catch {
+      // Pointer capture can already be gone if the browser canceled the pointer.
+    }
+    dragState = null;
+    svg.classList.remove("is-panning");
   }
 
   function showTooltip(event, metric) {
@@ -766,6 +906,42 @@
         renderMap();
       });
     });
+
+    document.querySelectorAll("[data-map-zoom]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const action = button.dataset.mapZoom;
+        if (action === "in") zoomMapBy(1.35, [view.width / 2, view.height / 2]);
+        if (action === "out") zoomMapBy(1 / 1.35, [view.width / 2, view.height / 2]);
+        if (action === "reset") resetMapView();
+        if (action === "district") focusSelectedDistrict();
+      });
+    });
+
+    const fullscreenButton = document.querySelector("[data-map-fullscreen]");
+    const mapPanel = document.querySelector(".map-panel");
+    fullscreenButton.addEventListener("click", () => {
+      if (document.fullscreenElement) {
+        document.exitFullscreen?.();
+        return;
+      }
+      const request = mapPanel.requestFullscreen?.();
+      request?.catch?.(() => {});
+    });
+
+    document.addEventListener("fullscreenchange", () => {
+      fullscreenButton.textContent = document.fullscreenElement === mapPanel ? "Exit" : "Full";
+    });
+
+    svg.addEventListener("wheel", (event) => {
+      event.preventDefault();
+      const factor = event.deltaY < 0 ? 1.18 : 1 / 1.18;
+      zoomMapBy(factor, svgPointFromEvent(event));
+    }, { passive: false });
+
+    svg.addEventListener("pointerdown", startMapPan);
+    svg.addEventListener("pointermove", continueMapPan);
+    svg.addEventListener("pointerup", endMapPan);
+    svg.addEventListener("pointercancel", endMapPan);
 
     document.getElementById("districtReceipts").addEventListener("click", () => {
       state.receiptDistrict = state.district;


### PR DESCRIPTION
Adds map controls to make the redistricting story easier to inspect.

Included:
- Zoom in / zoom out controls
- Reset zoom control
- Selected-district focus control
- Fullscreen map toggle
- Drag-to-pan and mouse-wheel zoom handling on the SVG map
- Overlay mode now draws 2022 outlines on top of the 2026 fill with a compact legend, so differences are easier to see while zoomed

QA:
- Verified local `/redistricting/` path loads with all map paths rendered
- Verified CD25 focus zoom transforms the map
- Verified overlay title and legend render
- Verified reset returns to scale 1
- Verified zoom-in changes the map transform
- Verified fullscreen toggles on and off
- Verified 390px mobile viewport has no horizontal overflow
- Verified no browser console errors or warnings