### PR TITLE
Add Axios role to resume; keep business card files local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Personal business card — contains a private cell number; keep local, don't publish
+business-card.html
+business-card.pdf

--- a/resume.html
+++ b/resume.html
@@ -147,11 +147,19 @@ hr {
     </div>
     <div class="section">
       <h2>Professional Experience</h2>
-      <h3>Freelance – Editor / Reporter <span style="font-weight:400; color:#888; font-size:0.92em;">Dec. 2024 – Present</span></h3>
+      <h3>Axios – Associate Editor, Breaking News <span style="font-weight:400; color:#888; font-size:0.85em; font-style:italic;">(formerly National Assistant Breaking News Editor)</span> <span style="font-weight:400; color:#888; font-size:0.92em;">Sept. 2025 – Present</span></h3>
       <ul>
-        <li>Report and edit freelance stories for local and national outlets.</li>
-        <li>Provide data analysis and investigative work on assignment.</li>
-        <li>Develop interactive news apps.</li>
+        <li>Edit Axios AM, the company’s flagship daily newsletter, helping set the national news agenda each morning and translating complex developments into clear, high-impact journalism using Axios’ Smart Brevity framework.</li>
+        <li>Edit high-stakes breaking and enterprise stories from pitch to publication, balancing speed, accuracy, fairness and clear reader framing.</li>
+        <li>Serve as a trusted deadline editor for senior reporters across desks, especially on live stories that demand fast judgment and careful sourcing.</li>
+        <li>Help lead coverage of redistricting, courts and data-heavy political stories through source work, docket monitoring, original analysis and rigorous fact-checking.</li>
+      </ul>
+
+      <h3>Freelance – Editor / Reporter <span style="font-weight:400; color:#888; font-size:0.92em;">Dec. 2024 – Sept. 2025</span></h3>
+      <ul>
+        <li>Reported and edited freelance stories for local and national outlets.</li>
+        <li>Provided data analysis and investigative work on assignment.</li>
+        <li>Developed interactive news apps.</li>
     </ul>
 
       <h3>The Tributary – Founding Editor <span style="font-weight:400; color:#888; font-size:0.92em;">Dec. 2020 – Dec. 2024</span></h3>


### PR DESCRIPTION
- resume.html: lead Professional Experience with Axios — Associate Editor, Breaking News (Sept. 2025–Present); end Freelance entry at Sept. 2025 and shift its bullets to past tense
- .gitignore: exclude local business-card.html/.pdf (contain a private cell number; GitHub Pages would otherwise publish them)